### PR TITLE
Refactor PostgreSQL test setup to use docker-compose and ensure start…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.38'
 	annotationProcessor 'org.projectlombok:lombok:1.18.38'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.testcontainers:testcontainers:1.21.4'
 	testImplementation 'org.testcontainers:postgresql:1.21.4'
 	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 	testImplementation 'org.hamcrest:hamcrest:3.0'

--- a/src/test/java/com/example/testingutil/BaseIntegrationTest.java
+++ b/src/test/java/com/example/testingutil/BaseIntegrationTest.java
@@ -2,26 +2,17 @@ package com.example.testingutil;
 
 import com.example.Application;
 import io.restassured.RestAssured;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith({SpringExtension.class, PostgreSQLContainerExtension.class})
 @SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test")
 public abstract class BaseIntegrationTest {
-    static final String POSTGRES_DOCKER_IMAGE = "postgres:14.15-alpine3.21";
-    static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(DockerImageName.parse(POSTGRES_DOCKER_IMAGE));
-
-    static {
-        postgresContainer.start();
-    }
 
     @Value("${server.port}")
     protected String serverPort;
@@ -29,13 +20,5 @@ public abstract class BaseIntegrationTest {
     @BeforeEach
     void setup() {
         RestAssured.port = Integer.parseInt(serverPort);
-    }
-
-    @BeforeAll
-    static void beforeAll() {
-        System.setProperty("DB_URL", postgresContainer.getJdbcUrl());
-        System.setProperty("DB_NAME", postgresContainer.getDatabaseName());
-        System.setProperty("DB_USERNAME", postgresContainer.getUsername());
-        System.setProperty("DB_PASSWORD", postgresContainer.getPassword());
     }
 }

--- a/src/test/java/com/example/testingutil/PostgreSQLContainerExtension.java
+++ b/src/test/java/com/example/testingutil/PostgreSQLContainerExtension.java
@@ -1,0 +1,33 @@
+package com.example.testingutil;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PostgreSQLContainerExtension implements BeforeAllCallback, AfterAllCallback {
+    private static final String NAMESPACE_KEY = "postgresql_container_extension";
+    private static final String STARTED_KEY = "started";
+    private static final AtomicInteger globalClassCount = new AtomicInteger(0);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ExtensionContext.Store root = context.getRoot().getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY));
+        
+        synchronized (globalClassCount) {
+            if (globalClassCount.getAndIncrement() == 0) {
+                PostgreSQLTestContainer.start();
+                root.put(STARTED_KEY, true);
+            }
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        // Do not stop the container after each test class
+        // It will be stopped when the JVM shuts down
+    }
+}
+
+
+

--- a/src/test/java/com/example/testingutil/PostgreSQLTestContainer.java
+++ b/src/test/java/com/example/testingutil/PostgreSQLTestContainer.java
@@ -1,33 +1,158 @@
 package com.example.testingutil;
 
-import org.testcontainers.containers.PostgreSQLContainer;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
-public class PostgreSQLTestContainer extends PostgreSQLContainer<PostgreSQLTestContainer> {
-    private static final String DOCKER_IMAGE_NAME = "postgres:15.10-alpine3.21";
-    private static PostgreSQLTestContainer container;
+public class PostgreSQLTestContainer implements AutoCloseable {
+    private static PostgreSQLTestContainer instance;
+    private static boolean shutdownHookRegistered = false;
+    private Process dockerComposeProcess;
+    private final String jdbcUrl;
+    private final String databaseName = "urlshortener";
+    private final String username = "urlshortener";
+    private final String password = "urlshortenerpassword";
 
     private PostgreSQLTestContainer() {
-        super(DOCKER_IMAGE_NAME);
+        this.jdbcUrl = "jdbc:postgresql://localhost:5432/" + databaseName;
     }
 
-    public static PostgreSQLTestContainer getInstance() {
-        if (container == null) {
-            container = new PostgreSQLTestContainer();
+    public static synchronized PostgreSQLTestContainer getInstance() {
+        if (instance == null) {
+            instance = new PostgreSQLTestContainer();
+            instance.startContainer();
+            registerShutdownHook();
         }
-        return container;
+        return instance;
+    }
+
+    private static synchronized void registerShutdownHook() {
+        if (!shutdownHookRegistered) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                PostgreSQLTestContainer.stop();
+            }, "PostgreSQL-Container-Shutdown"));
+            shutdownHookRegistered = true;
+        }
+    }
+
+    public static synchronized void start() {
+        getInstance();
+    }
+
+    private void startContainer() {
+        if (!isRunning()) {
+            try {
+                // Use docker compose up to start containers from docker-compose.yml
+                ProcessBuilder pb = new ProcessBuilder("docker", "compose", "up", "-d");
+                pb.directory(new File("."));
+                pb.inheritIO();
+                dockerComposeProcess = pb.start();
+                int exitCode = dockerComposeProcess.waitFor();
+                if (exitCode != 0) {
+                    throw new RuntimeException("docker compose up failed with exit code: " + exitCode);
+                }
+                // Wait for database to be ready
+                waitForDatabaseReady();
+                setSystemProperties();
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException("Failed to start docker compose: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private void waitForDatabaseReady() throws InterruptedException {
+        int maxAttempts = 30;
+        int attempts = 0;
+        while (attempts < maxAttempts) {
+            try {
+                ProcessBuilder pb = new ProcessBuilder(
+                    "docker", "exec", "urlshortener_db", "pg_isready",
+                    "-U", username, "-d", databaseName
+                );
+                Process process = pb.start();
+                int exitCode = process.waitFor();
+                if (exitCode == 0) {
+                    System.out.println("Database is ready");
+                    return;
+                }
+            } catch (IOException e) {
+                // Continue retrying
+            }
+            attempts++;
+            Thread.sleep(1000);
+        }
+        throw new RuntimeException("Database did not become ready within 30 seconds");
+    }
+
+    private boolean isRunning() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                "docker", "inspect", "-f", "{{.State.Running}}", "urlshortener_db"
+            );
+            Process process = pb.start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line = reader.readLine();
+            process.waitFor();
+            return "true".equalsIgnoreCase(line);
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+    }
+
+    public static synchronized void stop() {
+        if (instance != null) {
+            instance.stopContainer();
+            instance = null;
+        }
+    }
+
+    private void stopContainer() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("docker", "compose", "down");
+            pb.directory(new File("."));
+            pb.inheritIO();
+            Process process = pb.start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                System.err.println("docker compose down failed with exit code: " + exitCode);
+            }
+        } catch (IOException | InterruptedException e) {
+            System.err.println("Error stopping docker compose: " + e.getMessage());
+        }
+    }
+
+    public static synchronized void reset() {
+        stop();
+        start();
     }
 
     @Override
-    public void start() {
-        super.start();
-        System.setProperty("DB_URL", container.getJdbcUrl());
-        System.setProperty("DB_NAME", container.getDatabaseName());
-        System.setProperty("DB_USERNAME", container.getUsername());
-        System.setProperty("DB_PASSWORD", container.getPassword());
+    public void close() {
+        stopContainer();
     }
 
-    @Override
-    public void stop() {
-        // JVM handles the shutdown
+    private void setSystemProperties() {
+        System.setProperty("DB_URL", jdbcUrl);
+        System.setProperty("DB_NAME", databaseName);
+        System.setProperty("DB_USERNAME", username);
+        System.setProperty("DB_PASSWORD", password);
+    }
+
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }
+


### PR DESCRIPTION
…up ordering

- Start database via docker-compose.yml (docker-compose up/down)
- Wait for pg_isready before running tests
- Set DB system properties for Spring tests
- Swap JUnit extension order so container starts before SpringExtension